### PR TITLE
fix: Sort monthly account balance correctly

### DIFF
--- a/components/accounts/MonthlyAccountBalance.tsx
+++ b/components/accounts/MonthlyAccountBalance.tsx
@@ -62,13 +62,14 @@ export default function MonthlyAccountBalance({ account }: Props) {
           }
 
           months.push({
+            month: parsedMonth,
             name: displayMonth,
             balance: usd.value,
             displayBalance: displayValue,
           });
         }
 
-        months.sort((a, b) => a.name.localeCompare(b.name));
+        months.sort((a, b) => a.month.getTime() - b.month.getTime());
 
         return months;
       },


### PR DESCRIPTION
Compare the actual dates instead of their string representations.

Fixes #164
