### PR TITLE
ci: Only build Docker image once

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Build Docker Image
+
+on:
+  pull_request:
+  workflow_call:
+
+env:
+  IMAGE_NAME: zeroed-books/web
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build image
+        run: >
+          docker build
+          --build-arg RELEASE_NAME=${{ github.sha }}
+          --file Dockerfile
+          --label "runnumber=${GITHUB_RUN_ID}"
+          --tag $IMAGE_NAME
+          .
+
+      - name: Export image
+        run: >
+          docker save $IMAGE_NAME
+          | gzip > /tmp/zeroed-books-web.tar.gz
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: zeroed-books-web
+          path: /tmp/zeroed-books-web.tar.gz

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ env:
   IMAGE_NAME: web
 
 jobs:
+  build:
+    uses: ./.github/workflows/build.yml
   review:
     uses: ./.github/workflows/review.yml
 
@@ -17,6 +19,7 @@ jobs:
   # See also https://docs.docker.com/docker-hub/builds/
   push:
     needs:
+      - build
       - review
 
     runs-on: ubuntu-latest
@@ -25,10 +28,14 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Download container artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: zeroed-books-web
+          path: /tmp
 
-      - name: Build image
-        run: docker build . --build-arg RELEASE_NAME=${{ github.sha }} --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+      - name: Load docker image
+        run: docker load < /tmp/zeroed-books-web.tar.gz
 
       - name: Log in to registry
         # This is where you will update the personal access token to GITHUB_TOKEN

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -2,23 +2,9 @@ name: Review Build
 
 on:
   pull_request:
-    branches:
-      - main
   workflow_call:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Ensure application builds
-        run: >
-          docker build
-          --build-arg RELEASE_NAME=${{ github.sha }}
-          --file Dockerfile
-          .
-
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Build the Docker image once and pass it between jobs instead of building
during the review build and the publishing build.
